### PR TITLE
Fix missing return statements in loading handlers

### DIFF
--- a/src/pages/Homepage/components/Banner/Banner.jsx
+++ b/src/pages/Homepage/components/Banner/Banner.jsx
@@ -10,7 +10,7 @@ const Banner = () => {
   const randNum = (Math.random() * 20).toFixed(0);
   console.log(randNum);
   if (isLoading) return <LodingSpinner />;
-  if (isError) return <Alert variant="danger">{error.message};</Alert>;
+  if (isError) return <Alert variant="danger">{error.message}</Alert>;
   return (
     <div
       className="banner"

--- a/src/pages/Homepage/components/PopularMoviesSlide/PopularMoviesSlide.jsx
+++ b/src/pages/Homepage/components/PopularMoviesSlide/PopularMoviesSlide.jsx
@@ -9,8 +9,9 @@ import responsive from "../../../../constants/responsive";
 const PopularMoviesSlide = () => {
   const { data, isLoading, isError, error } = usePopularMoviesQuery();
 
-  if (isLoading) <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
-  if (isError) <Alert variant="danger">{error.message};</Alert>;
+  if (isLoading)
+    return <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
+  if (isError) return <Alert variant="danger">{error.message}</Alert>;
   return (
     <MovieSlider
       data={data}

--- a/src/pages/Homepage/components/TopLatedMoviesSlide/TopLatedMoviesSlide.jsx
+++ b/src/pages/Homepage/components/TopLatedMoviesSlide/TopLatedMoviesSlide.jsx
@@ -8,8 +8,9 @@ import responsive from "../../../../constants/responsive";
 const TopLatedMoviesSlide = () => {
   const { data, isLoading, isError, error } = useTopLatedMoviesQuery();
 
-  if (isLoading) <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
-  if (isError) <Alert variant="danger">{error.message};</Alert>;
+  if (isLoading)
+    return <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
+  if (isError) return <Alert variant="danger">{error.message}</Alert>;
   return (
     <MovieSlider
       data={data}

--- a/src/pages/Homepage/components/UpcomingMoviesSlide/UpcomingMoviesSlide.jsx
+++ b/src/pages/Homepage/components/UpcomingMoviesSlide/UpcomingMoviesSlide.jsx
@@ -9,8 +9,9 @@ import responsive from "../../../../constants/responsive";
 const UpcomingMoviesSlide = () => {
   const { data, isLoading, isError, error } = useUpcomingMoviesQuery();
 
-  if (isLoading) <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
-  if (isError) <Alert variant="danger">{error.message};</Alert>;
+  if (isLoading)
+    return <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
+  if (isError) return <Alert variant="danger">{error.message}</Alert>;
   return (
     <MovieSlider
       data={data}

--- a/src/pages/MovieDetail/MovieDetailPage.jsx
+++ b/src/pages/MovieDetail/MovieDetailPage.jsx
@@ -29,8 +29,9 @@ const MovieDetailPage = () => {
   console.log("recomend", recomend);
   console.log("videoData", videoData);
 
-  if (isLoading) <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
-  if (isError) <Alert variant="danger">{error.message};</Alert>;
+  if (isLoading)
+    return <ClipLoader color="#E90813" size={65} speedMultiplier={1.2} />;
+  if (isError) return <Alert variant="danger">{error.message}</Alert>;
 
   const handleShowMoreReviews = () => {
     if (visibleReviews === 3) {

--- a/src/pages/Movies/MoviesPage.jsx
+++ b/src/pages/Movies/MoviesPage.jsx
@@ -65,7 +65,7 @@ const MoviesPage = () => {
   }, [genre]);
 
   if (isLoading) return <LodingSpinner />;
-  if (isError) return <Alert variant="danger">{error.message};</Alert>;
+  if (isError) return <Alert variant="danger">{error.message}</Alert>;
   if (data?.results?.length === 0) return <NoResults />;
 
   return (


### PR DESCRIPTION
## Summary
- fix missing return statements in Homepage slides
- handle loading/error state properly in banner, movie pages, and detail page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846797661348324a6d267ffbd13740d